### PR TITLE
Rectified broken link on TrainModelAndDeploy.md

### DIFF
--- a/Documentation/TrainModelAndDeploy.md
+++ b/Documentation/TrainModelAndDeploy.md
@@ -125,7 +125,7 @@ This function renders the environment based on its current state.
 
 `python examples/train.py --should_render --print_progress --number_of_snakes 4`
 
-*Please refer to https://github.com/awslab/sagemaker-battlesnake-ai/TrainingEnvironment/examples/train.py for the other hyperparameters*
+*Please refer to https://github.com/awslabs/sagemaker-battlesnake-ai/blob/master/TrainingEnvironment/examples/train.py for the other hyperparameters*
 
 This code uses multi-agent DQN to train the bots. The `N` snakes share the same Qnetwork and the network is configured as follows:
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated "Please refer to https://github.com/awslab/sagemaker-battlesnake-ai/TrainingEnvironment/examples/train.py for the other hyperparameters" link under The DQN Network heading, to "Please refer to https://github.com/awslabs/sagemaker-battlesnake-ai/blob/master/TrainingEnvironment/examples/train.py for the other hyperparameters"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
