### PR TITLE
Fixed the snake customization docs link in the cloud formation template

### DIFF
--- a/deployment/CloudFormation/template.yaml
+++ b/deployment/CloudFormation/template.yaml
@@ -30,11 +30,11 @@ Parameters:
     Default: "#128a7a"
     Type: String
   SnakeHead:
-    Description: "Snake head : evil, fang, pixel, safe, ... (see: https://docs.battlesnake.com/snake-customization)"
+    Description: "Snake head : evil, fang, pixel, safe, ... (see: https://docs.battlesnake.com/references/personalization)"
     Default: bendr
     Type: String
   SnakeTail:
-    Description: "Snake tail : sharp, pixel, bolt, curled, ... (see: https://docs.battlesnake.com/snake-customization)"
+    Description: "Snake tail : sharp, pixel, bolt, curled, ... (see: https://docs.battlesnake.com/references/personalization)"
     Default: freckled
     Type: String
   SagemakerTrainingInstanceType:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The snake customization page on the battlesnake docs site changed, probably last year when Docs.battlesnake.com was rebuilt.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
