### PR TITLE
Fix the attribute names in the API response to specify custom head and tail images

### DIFF
--- a/deployment/LambdaGateway/src/lambda.py
+++ b/deployment/LambdaGateway/src/lambda.py
@@ -66,8 +66,8 @@ def ping():
             "apiversion": "1",
             "author": "my_user_name",
             "color": os.environ['SNAKE_COLOR'],
-            "headType": os.environ['SNAKE_HEAD'],
-            "tailType": os.environ['SNAKE_TAIL']
+            "head": os.environ['SNAKE_HEAD'],
+            "tail": os.environ['SNAKE_TAIL']
             })
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The attribute names in the API response to specify custom head and tail images have changed from 'headType' and 'tailType' to 'head' and 'tail' respectively.  See https://docs.battlesnake.com/references/personalization for details.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
